### PR TITLE
Change text when soundtrack changed, add mapping for values to labels

### DIFF
--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -1,0 +1,33 @@
+import { GameSoundtrackLabel, GameSoundtrackValue, WeatherVariantLabel, WeatherVariantValue } from './enums';
+
+export const GameSoundtrackList = [
+    GameSoundtrackValue.Original,
+    GameSoundtrackValue.WWCF,
+    GameSoundtrackValue.NL,
+    GameSoundtrackValue.NH,
+    GameSoundtrackValue.Random
+];
+
+export const WeatherVariantList = [
+    WeatherVariantValue.Real,
+    WeatherVariantValue.Normal,
+    WeatherVariantValue.Rainy,
+    WeatherVariantValue.Snowy,
+    WeatherVariantValue.Random
+];
+
+export const soundtrackValueMap: Record<GameSoundtrackValue, GameSoundtrackLabel> = {
+    [GameSoundtrackValue.Original]: GameSoundtrackLabel.Original,
+    [GameSoundtrackValue.WWCF]: GameSoundtrackLabel.WWCF,
+    [GameSoundtrackValue.NL]: GameSoundtrackLabel.NL,
+    [GameSoundtrackValue.NH]: GameSoundtrackLabel.NH,
+    [GameSoundtrackValue.Random]: GameSoundtrackLabel.Random
+};
+
+export const weatherValueMap: Record<WeatherVariantValue, WeatherVariantLabel> = {
+    [WeatherVariantValue.Real]: WeatherVariantLabel.Real,
+    [WeatherVariantValue.Normal]: WeatherVariantLabel.Normal,
+    [WeatherVariantValue.Rainy]: WeatherVariantLabel.Rainy,
+    [WeatherVariantValue.Snowy]: WeatherVariantLabel.Snowy,
+    [WeatherVariantValue.Random]: WeatherVariantLabel.Random
+};

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -1,4 +1,4 @@
-import { GameSoundtrackLabel, GameSoundtrackValue, WeatherVariantLabel, WeatherVariantValue } from './enums';
+import { GameSoundtrackLabel, GameSoundtrackValue, SoundEffectLabel, SoundEffectValue, WeatherVariantLabel, WeatherVariantValue } from './enums';
 
 export const GameSoundtrackList = [
     GameSoundtrackValue.Original,
@@ -30,4 +30,9 @@ export const weatherValueMap: Record<WeatherVariantValue, WeatherVariantLabel> =
     [WeatherVariantValue.Rainy]: WeatherVariantLabel.Rainy,
     [WeatherVariantValue.Snowy]: WeatherVariantLabel.Snowy,
     [WeatherVariantValue.Random]: WeatherVariantLabel.Random
+};
+
+export const soundEffectValueMap: Record<SoundEffectValue, SoundEffectLabel> = {
+    [SoundEffectValue.Rain]: SoundEffectLabel.Rain,
+    [SoundEffectValue.Thunder]: SoundEffectLabel.Thunder
 };

--- a/src/common/index.ts
+++ b/src/common/index.ts
@@ -1,2 +1,5 @@
+export * from './constants';
 export * from './enums';
 export * from './interfaces';
+export * from './service';
+export * from './types';

--- a/src/common/interfaces.ts
+++ b/src/common/interfaces.ts
@@ -1,13 +1,8 @@
-import { GameSoundtrackLabel, GameSoundtrackValue, SoundEffectLabel, SoundEffectValue, WeatherVariantLabel, WeatherVariantValue } from './enums';
+import { GameSoundtrackValue, WeatherVariantValue } from './enums';
 
 export interface ISettings {
     gameSoundtrack: GameSoundtrackValue,
     weatherVariant: WeatherVariantValue,
     rainSoundEffectOn: boolean,
     thunderSoundEffectOn: boolean,
-}
-
-export interface IValueLabel {
-    value: GameSoundtrackValue | WeatherVariantValue | SoundEffectValue,
-    label: GameSoundtrackLabel | WeatherVariantLabel | SoundEffectLabel
 }

--- a/src/common/service.tsx
+++ b/src/common/service.tsx
@@ -1,5 +1,5 @@
-import { soundtrackValueMap, weatherValueMap } from './constants';
-import { FormattedHour, GameSoundtrackLabel, GameSoundtrackValue, LocalStorageKey, WeatherVariantLabel, WeatherVariantValue } from './enums';
+import { soundEffectValueMap, soundtrackValueMap, weatherValueMap } from './constants';
+import { FormattedHour, GameSoundtrackLabel, GameSoundtrackValue, LocalStorageKey, SoundEffectLabel, SoundEffectValue, WeatherVariantLabel, WeatherVariantValue } from './enums';
 import { ISettings } from './interfaces';
 
 export const getHour = (time: Date): FormattedHour => {
@@ -29,3 +29,5 @@ export const getSettingsFromLocalStorage = (): ISettings => {
 export const getSoundtrackLabelFromValue = (value: GameSoundtrackValue): GameSoundtrackLabel => (soundtrackValueMap[value]);
 
 export const getWeatherLabelFromValue = (value: WeatherVariantValue): WeatherVariantLabel => (weatherValueMap[value]);
+
+export const getSoundEffectLabelFromValue = (value: SoundEffectValue): SoundEffectLabel => (soundEffectValueMap[value]);

--- a/src/common/service.tsx
+++ b/src/common/service.tsx
@@ -1,4 +1,5 @@
-import { FormattedHour, GameSoundtrackValue, LocalStorageKey, WeatherVariantValue } from './enums';
+import { soundtrackValueMap, weatherValueMap } from './constants';
+import { FormattedHour, GameSoundtrackLabel, GameSoundtrackValue, LocalStorageKey, WeatherVariantLabel, WeatherVariantValue } from './enums';
 import { ISettings } from './interfaces';
 
 export const getHour = (time: Date): FormattedHour => {
@@ -23,4 +24,8 @@ export const getSettingsFromLocalStorage = (): ISettings => {
     };
 
     return JSON.parse((getFromLocalStorage(LocalStorageKey.Object) ?? JSON.stringify(initialSettings)));
-}
+};
+
+export const getSoundtrackLabelFromValue = (value: GameSoundtrackValue): GameSoundtrackLabel => (soundtrackValueMap[value]);
+
+export const getWeatherLabelFromValue = (value: WeatherVariantValue): WeatherVariantLabel => (weatherValueMap[value]);

--- a/src/components/MainText/MainText.tsx
+++ b/src/components/MainText/MainText.tsx
@@ -1,12 +1,28 @@
 import { PropsWithChildren } from 'react';
-import { FormattedHour } from '../../common';
+import { FormattedHour, GameSoundtrackLabel, GameSoundtrackValue } from '../../common';
 import { useTime } from '../../hooks';
-import { getHour } from '../../common/service';
+import { getHour, getSettingsFromLocalStorage } from '../../common/service';
 
 export const MainText = () => {
     const time: Date = useTime();
     const timeString: string = time.toLocaleTimeString(['en-AU'], { timeStyle: 'short' }).split(' ').join('');
     const hour: FormattedHour = getHour(time);
+
+    const getLabelFromValue = (value: GameSoundtrackValue): GameSoundtrackLabel => {
+        const valueToLabelMap = {
+            [GameSoundtrackValue.Original]: GameSoundtrackLabel.Original,
+            [GameSoundtrackValue.WWCF]: GameSoundtrackLabel.WWCF,
+            [GameSoundtrackValue.NL]: GameSoundtrackLabel.NL,
+            [GameSoundtrackValue.NH]: GameSoundtrackLabel.NH,
+            [GameSoundtrackValue.Random]: GameSoundtrackLabel.Random,
+        };
+
+        return valueToLabelMap[value];
+    };
+
+    const soundtrackValue: GameSoundtrackValue = getSettingsFromLocalStorage().gameSoundtrack;
+    const soundtrack: GameSoundtrackLabel = getLabelFromValue(soundtrackValue);
+
 
     const HighlightText = ({ children }: PropsWithChildren) => {
         return <div className="text-lm-text-blue dark:text-dm-text-green inline">
@@ -17,7 +33,7 @@ export const MainText = () => {
     return (
         <p className="font-extrabold leading-loose">
             It's currently <HighlightText>{timeString}</HighlightText> and <HighlightText>cloudy</HighlightText>!<br />
-            Now playing: <HighlightText>{hour} AC: NH Soundtrack</HighlightText>
+            Now playing: <HighlightText>{hour} AC: {soundtrack} Soundtrack</HighlightText>
         </p>
     )
 }

--- a/src/components/MainText/MainText.tsx
+++ b/src/components/MainText/MainText.tsx
@@ -1,27 +1,15 @@
 import { PropsWithChildren } from 'react';
 import { FormattedHour, GameSoundtrackLabel, GameSoundtrackValue } from '../../common';
 import { useTime } from '../../hooks';
-import { getHour, getSettingsFromLocalStorage } from '../../common/service';
+import { getHour, getSettingsFromLocalStorage, getSoundtrackLabelFromValue } from '../../common/service';
 
 export const MainText = () => {
     const time: Date = useTime();
     const timeString: string = time.toLocaleTimeString(['en-AU'], { timeStyle: 'short' }).split(' ').join('');
     const hour: FormattedHour = getHour(time);
 
-    const getLabelFromValue = (value: GameSoundtrackValue): GameSoundtrackLabel => {
-        const valueToLabelMap = {
-            [GameSoundtrackValue.Original]: GameSoundtrackLabel.Original,
-            [GameSoundtrackValue.WWCF]: GameSoundtrackLabel.WWCF,
-            [GameSoundtrackValue.NL]: GameSoundtrackLabel.NL,
-            [GameSoundtrackValue.NH]: GameSoundtrackLabel.NH,
-            [GameSoundtrackValue.Random]: GameSoundtrackLabel.Random,
-        };
-
-        return valueToLabelMap[value];
-    };
-
     const soundtrackValue: GameSoundtrackValue = getSettingsFromLocalStorage().gameSoundtrack;
-    const soundtrack: GameSoundtrackLabel = getLabelFromValue(soundtrackValue);
+    const soundtrack: GameSoundtrackLabel = getSoundtrackLabelFromValue(soundtrackValue);
 
 
     const HighlightText = ({ children }: PropsWithChildren) => {

--- a/src/components/RadioInputGroup/RadioInputGroup.tsx
+++ b/src/components/RadioInputGroup/RadioInputGroup.tsx
@@ -1,23 +1,33 @@
 import { ChangeEvent } from 'react';
-import { IValueLabel, LocalStorageKey } from '../../common';
+import { GameSoundtrackLabel, GameSoundtrackValue, LocalStorageKey, WeatherVariantLabel, WeatherVariantValue } from '../../common';
+import { getSoundtrackLabelFromValue, getWeatherLabelFromValue } from '../../common/service';
 
 interface IInputGroupProps {
     name: LocalStorageKey;
-    valuesLabels: IValueLabel[];
+    values: GameSoundtrackValue[] | WeatherVariantValue[];
     selectedOption: string;
     onChange: (event: ChangeEvent<HTMLInputElement>) => void;
 }
 
-export const RadioInputGroup = ({ name, valuesLabels, selectedOption, onChange }: IInputGroupProps) => (
-    <>
-        {valuesLabels.map(({ value, label }) => (
-            <>
-                <input type='radio' name={name} id={value} value={value} checked={selectedOption == value} onChange={onChange} />
-                <label role='radio' className='radio' htmlFor={value}>
-                    {label}
-                </label>
-            </>
-        )
-        )}
-    </>
-);
+export const RadioInputGroup = ({ name, values, selectedOption, onChange }: IInputGroupProps) => {
+    const isGameSoundtrackValue = (value: GameSoundtrackValue | WeatherVariantValue): value is GameSoundtrackValue => {
+        return Object.values(GameSoundtrackValue).includes(value as GameSoundtrackValue);
+    };
+
+    return (
+        <>
+            {values.map((value) => {
+                const label: GameSoundtrackLabel | WeatherVariantLabel = isGameSoundtrackValue(value) ? getSoundtrackLabelFromValue(value) : getWeatherLabelFromValue(value);
+
+                return (
+                    <>
+                        <input type='radio' name={name} id={value} value={value} checked={selectedOption == value} onChange={onChange} />
+                        <label role='radio' className='radio' htmlFor={value}>
+                            {label}
+                        </label>
+                    </>
+                );
+            })}
+        </>
+    );
+};

--- a/src/components/RadioInputGroup/RadioInputGroup.tsx
+++ b/src/components/RadioInputGroup/RadioInputGroup.tsx
@@ -1,4 +1,4 @@
-import { ChangeEvent } from 'react';
+import { ChangeEvent, Fragment } from 'react';
 import { GameSoundtrackLabel, GameSoundtrackValue, LocalStorageKey, WeatherVariantLabel, WeatherVariantValue } from '../../common';
 import { getSoundtrackLabelFromValue, getWeatherLabelFromValue } from '../../common/service';
 
@@ -20,12 +20,12 @@ export const RadioInputGroup = ({ name, values, selectedOption, onChange }: IInp
                 const label: GameSoundtrackLabel | WeatherVariantLabel = isGameSoundtrackValue(value) ? getSoundtrackLabelFromValue(value) : getWeatherLabelFromValue(value);
 
                 return (
-                    <>
+                    <Fragment key={value}>
                         <input type='radio' name={name} id={value} value={value} checked={selectedOption == value} onChange={onChange} />
                         <label role='radio' className='radio' htmlFor={value}>
                             {label}
                         </label>
-                    </>
+                    </Fragment>
                 );
             })}
         </>

--- a/src/components/Toggle/Toggle.tsx
+++ b/src/components/Toggle/Toggle.tsx
@@ -1,18 +1,18 @@
-import { IValueLabel } from '../../common';
 import { ChangeEvent } from 'react';
+import { SoundEffectValue, getSoundEffectLabelFromValue } from '../../common';
 
 interface IToggleProps {
-    valuesLabel: IValueLabel;
+    value: SoundEffectValue;
     selectedOption: boolean;
     onChange: (event: ChangeEvent<HTMLInputElement>) => void;
 }
 
-export const Toggle = ({ valuesLabel, selectedOption, onChange }: IToggleProps) => {
+export const Toggle = ({ value, selectedOption, onChange }: IToggleProps) => {
     return (
         <div className='flex items-center'>
-            <p>{valuesLabel.label}</p>
+            <p>{getSoundEffectLabelFromValue(value)}</p>
             <label className="toggle">
-                <input type="checkbox" name="soundEffects" id={valuesLabel.value} checked={selectedOption} onChange={onChange} />
+                <input type="checkbox" name="soundEffects" id={value} checked={selectedOption} onChange={onChange} />
                 <span className="toggleCircle" />
             </label>
         </div>

--- a/src/components/VideoSettings/VideoSettings.tsx
+++ b/src/components/VideoSettings/VideoSettings.tsx
@@ -53,12 +53,12 @@ export const VideoSettings = () => {
                 <div className='flex-col'>
                     <div className='flex gap-[50px]'>
                         <Toggle
-                            valuesLabel={{ value: SoundEffectValue.Rain, label: SoundEffectLabel.Rain }}
+                            value={SoundEffectValue.Rain}
                             selectedOption={settings.rainSoundEffectOn}
                             onChange={(changeEvent) => handleOptionChange({ changeEvent: changeEvent, stateVariable: LocalStorageKey.RainSoundEffectOn })}
                         />
                         <Toggle
-                            valuesLabel={{ value: SoundEffectValue.Thunder, label: SoundEffectLabel.Thunder }}
+                            value={SoundEffectValue.Thunder}
                             selectedOption={settings.thunderSoundEffectOn}
                             onChange={(changeEvent) => handleOptionChange({ changeEvent: changeEvent, stateVariable: LocalStorageKey.ThunderSoundEffectOn })}
                         />

--- a/src/components/VideoSettings/VideoSettings.tsx
+++ b/src/components/VideoSettings/VideoSettings.tsx
@@ -1,12 +1,13 @@
 import './VideoSettings.css';
 import { useEffect, ChangeEvent } from 'react';
 import { useState } from 'react';
-import { GameSoundtrackLabel, GameSoundtrackValue, ISettings, LocalStorageKey, SoundEffectLabel, SoundEffectValue, WeatherVariantLabel, WeatherVariantValue } from '../../common';
+import { ISettings, LocalStorageKey, SoundEffectLabel, SoundEffectValue } from '../../common';
 import { VideoSettingsGroup } from '../VideoSettingsGroup';
 import { RadioInputGroup } from '../RadioInputGroup';
 import { Toggle } from '../Toggle';
 import { VolumeControl } from '../VolumeControl';
 import { getSettingsFromLocalStorage } from '../../common/service';
+import { GameSoundtrackList, WeatherVariantList } from '../../common/constants';
 
 export const VideoSettings = () => {
     const [settings, setSettings] = useState<ISettings>(getSettingsFromLocalStorage);
@@ -33,13 +34,7 @@ export const VideoSettings = () => {
             <VideoSettingsGroup title='Change soundtrack'>
                 <RadioInputGroup
                     name={LocalStorageKey.GameSoundtrack}
-                    valuesLabels={[
-                        { value: GameSoundtrackValue.Original, label: GameSoundtrackLabel.Original },
-                        { value: GameSoundtrackValue.WWCF, label: GameSoundtrackLabel.WWCF },
-                        { value: GameSoundtrackValue.NL, label: GameSoundtrackLabel.NL },
-                        { value: GameSoundtrackValue.NH, label: GameSoundtrackLabel.NH },
-                        { value: GameSoundtrackValue.Random, label: GameSoundtrackLabel.Random }
-                    ]}
+                    values={GameSoundtrackList}
                     selectedOption={settings.gameSoundtrack}
                     onChange={(changeEvent) => handleOptionChange({ changeEvent, stateVariable: LocalStorageKey.GameSoundtrack })}
                 />
@@ -48,13 +43,7 @@ export const VideoSettings = () => {
             <VideoSettingsGroup title='Change weather variant'>
                 <RadioInputGroup
                     name={LocalStorageKey.WeatherVariant}
-                    valuesLabels={[
-                        { value: WeatherVariantValue.Real, label: WeatherVariantLabel.Real },
-                        { value: WeatherVariantValue.Normal, label: WeatherVariantLabel.Normal },
-                        { value: WeatherVariantValue.Rainy, label: WeatherVariantLabel.Rainy },
-                        { value: WeatherVariantValue.Snowy, label: WeatherVariantLabel.Snowy },
-                        { value: WeatherVariantValue.Random, label: WeatherVariantLabel.Random }
-                    ]}
+                    values={WeatherVariantList}
                     selectedOption={settings.weatherVariant}
                     onChange={(changeEvent) => handleOptionChange({ changeEvent, stateVariable: LocalStorageKey.WeatherVariant })}
                 />


### PR DESCRIPTION
### What does this PR do?
- Changes the text displayed to match the selected soundtrack
- Refactors to use mapping function to map value to label, instead of having to pass in value and label
- Fixes each element must have a unique key error

### Screenshots
<img width="941" alt="image" src="https://github.com/user-attachments/assets/2a5de268-0362-4ba3-bb25-613a01c50db1">
