### PR TITLE
Add change hour

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,7 +4,7 @@ import { About, Main } from './pages';
 
 function App() {
     return (
-        <div className='flex flex-col h-svh px-0 lg:px-[96px] font-main text-[#FFF9F5] dark:text-dm-white bg-lm-bg-green dark:bg-dm-bg-dark-green'>
+        <div className='flex flex-col h-full px-0 lg:px-[96px] font-main text-[#FFF9F5] dark:text-dm-white bg-lm-bg-green dark:bg-dm-bg-dark-green'>
             <HashRouter>
                 <Navbar />
                 <Routes>

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -1,4 +1,4 @@
-import { GameSoundtrackLabel, GameSoundtrackValue, SoundEffectLabel, SoundEffectValue, WeatherVariantLabel, WeatherVariantValue } from './enums';
+import { GameSoundtrackLabel, GameSoundtrackValue, GameTime, SoundEffectLabel, SoundEffectValue, WeatherVariantLabel, WeatherVariantValue } from './enums';
 import { ISettings } from './interfaces';
 
 export const GameSoundtrackList = [
@@ -42,5 +42,6 @@ export const initialSettings: ISettings = {
     gameSoundtrack: GameSoundtrackValue.NH,
     weatherVariant: WeatherVariantValue.Real,
     rainSoundEffectOn: false,
-    thunderSoundEffectOn: false
+    thunderSoundEffectOn: false,
+    gameTime: GameTime.Current
 };

--- a/src/common/enums.ts
+++ b/src/common/enums.ts
@@ -138,6 +138,7 @@ export enum LocalStorageKey {
     WeatherVariant = 'weatherVariant',
     RainSoundEffectOn = 'rainSoundEffectOn',
     ThunderSoundEffectOn = 'thunderSoundEffectOn',
+    GameTime = 'gameTime',
     Object = 'object'
 };
 
@@ -181,4 +182,32 @@ export enum SoundEffectValue {
 export enum SoundEffectLabel {
     Rain = 'Rain',
     Thunder = 'Thunder',
+};
+
+export enum GameTime {
+    Current = 'current',
+    Hour1am = '1AM',
+    Hour2am = '2AM',
+    Hour3am = '3AM',
+    Hour4am = '4AM',
+    Hour5am = '5AM',
+    Hour6am = '6AM',
+    Hour7am = '7AM',
+    Hour8am = '8AM',
+    Hour9am = '9AM',
+    Hour10am = '10AM',
+    Hour11am = '11AM',
+    Hour12pm = '12PM',
+    Hour1pm = '1PM',
+    Hour2pm = '2PM',
+    Hour3pm = '3PM',
+    Hour4pm = '4PM',
+    Hour5pm = '5PM',
+    Hour6pm = '6PM',
+    Hour7pm = '7PM',
+    Hour8pm = '8PM',
+    Hour9pm = '9PM',
+    Hour10pm = '10PM',
+    Hour11pm = '11PM',
+    Hour12am = '12AM',
 };

--- a/src/common/interfaces.ts
+++ b/src/common/interfaces.ts
@@ -1,8 +1,9 @@
-import { GameSoundtrackValue, WeatherVariantValue } from './enums';
+import { GameSoundtrackValue, GameTime, WeatherVariantValue } from './enums';
 
 export interface ISettings {
     gameSoundtrack: GameSoundtrackValue,
     weatherVariant: WeatherVariantValue,
+    gameTime: GameTime,
     rainSoundEffectOn: boolean,
-    thunderSoundEffectOn: boolean,
+    thunderSoundEffectOn: boolean
 }

--- a/src/common/service.tsx
+++ b/src/common/service.tsx
@@ -1,14 +1,20 @@
 import { initialSettings, soundEffectValueMap, soundtrackValueMap, weatherValueMap } from './constants';
-import { FormattedHour, GameSoundtrackLabel, GameSoundtrackValue, LocalStorageKey, SoundEffectLabel, SoundEffectValue, WeatherVariantLabel, WeatherVariantValue } from './enums';
+import { FormattedHour, GameSoundtrackLabel, GameSoundtrackValue, GameTime, LocalStorageKey, SoundEffectLabel, SoundEffectValue, WeatherVariantLabel, WeatherVariantValue } from './enums';
 import { ISettings } from './interfaces';
 
-export const getHour = (time: Date): FormattedHour => {
+export const getFormattedHour = (time: Date): FormattedHour => {
     const currentHour: number = time.getHours();
 
     const isAm: boolean = currentHour <= 12;
     const hourString: string = isAm ? currentHour == 0 ? '12AM' : `${currentHour.toString()}AM` : `${(currentHour - 12).toString()}PM`;
 
     return FormattedHour[hourString as keyof typeof FormattedHour];
+};
+
+export const getHour = (time: Date): FormattedHour => {
+    const customHour: GameTime | undefined = getSettingsFromLocalStorage().gameTime;
+    const isCustomHour: boolean = customHour !== 'current';
+    return isCustomHour ? FormattedHour[customHour as keyof typeof FormattedHour] : getFormattedHour(time);
 };
 
 export const getSettingsFromLocalStorage = (): ISettings => {

--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -1,6 +1,6 @@
 export const Footer = () => {
     return (
-        <div className="z-10 text-[8px] lg:text-[12px] m-[12px] h-fit self-center text-center">
+        <div className="z-10 text-[8px] lg:text-[12px] my-[24px] mx-[12px] h-fit self-center text-center">
             <p className="font-bold">
                 Made with ♥ by Kim Pham - View code on <a className="link" href="https://github.com/kimypham/ac-music" target="_blank">Github</a> - Questions/comments? <a className="link" href="mailto:km.phm2@gmail.com">Contact me!</a>
             </p>

--- a/src/components/Navbar/Navbar.tsx
+++ b/src/components/Navbar/Navbar.tsx
@@ -1,7 +1,7 @@
 import { Link } from "react-router-dom";
 
 export const Navbar = () => (
-    <nav className="flex py-[24px] px-[24px] lg:px-0 font-black text-[16px] lg:text-[20px] z-20">
+    <nav className="flex py-[24px] px-[24px] font-black text-[16px] lg:text-[20px] z-20">
         <h1 className="w-full"><Link to="/">AC Hourly Music</Link></h1>
         <Link to="/about" className="link">About</Link>
         {/* TODO: Maybe only show settings on mobile view

--- a/src/components/Video/Video.tsx
+++ b/src/components/Video/Video.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { FormattedHour, GameSoundtrackValue, NHVideoId, NLVideoId, OriginalVideoId, WWCFVideoId } from '../../common';
+import { FormattedHour, GameSoundtrackList, GameSoundtrackValue, NHVideoId, NLVideoId, OriginalVideoId, WWCFVideoId } from '../../common';
 import { getHour, getSettingsFromLocalStorage } from '../../common/service';
 import { GameSoundtrackOption, VideoId } from '../../common/types';
 import { useTime } from '../../hooks';
@@ -11,12 +11,9 @@ export const Video = () => {
     const time: Date = useTime();
     const hour: FormattedHour = getHour(time);
 
-    const getRandomSoundtrackVideoId = (hour: FormattedHour): VideoId => {
-        const gameSoundtrackList: GameSoundtrackOption[] = [GameSoundtrackValue.Original, GameSoundtrackValue.WWCF, GameSoundtrackValue.NL, GameSoundtrackValue.NH];
-        const randomNumber: number = Math.floor(Math.random() * gameSoundtrackList.length);
-
-        const randomSoundtrack: GameSoundtrackOption = gameSoundtrackList[randomNumber];
-        return getVideoId(randomSoundtrack, hour);
+    const getRandomSoundtrack = (): GameSoundtrackOption => {
+        const randomNumber: number = Math.floor(Math.random() * GameSoundtrackList.length);
+        return GameSoundtrackList[randomNumber] as GameSoundtrackOption;
     };
 
     const getVideoId = (soundtrack: GameSoundtrackOption, hour: FormattedHour): VideoId => {
@@ -33,8 +30,8 @@ export const Video = () => {
     };
 
     useEffect(() => {
-        setVideoId(soundtrack === GameSoundtrackValue.Random ? getRandomSoundtrackVideoId(hour) : getVideoId(soundtrack, hour));
-    }, [soundtrack]);
+        setVideoId(soundtrack === GameSoundtrackValue.Random ? getVideoId(getRandomSoundtrack(), hour) : getVideoId(soundtrack, hour));
+    }, [soundtrack, hour]);
 
     return (
         <div className='overflow-hidden pt-[56.25%] w-full relative'>

--- a/src/components/VideoSettings/VideoSettings.css
+++ b/src/components/VideoSettings/VideoSettings.css
@@ -17,6 +17,13 @@ input[type="checkbox"]:checked+.toggleCircle:hover {
     background-color: #62523a;
 }
 
+select {
+    background-color: var(--lm-hover-white);
+    height: 40px;
+    text-align: center;
+    cursor: pointer;
+}
+
 .radio {
     background-color: var(--lm-hover-white);
     width: 85px;
@@ -24,13 +31,11 @@ input[type="checkbox"]:checked+.toggleCircle:hover {
     border-radius: 30px;
     align-content: center;
     cursor: pointer;
-    -webkit-user-select: none;
-    -ms-user-select: none;
-    user-select: none;
 }
 
 .radio:hover,
-.toggleCircle:hover {
+.toggleCircle:hover,
+select:hover {
     background-color: #d2c7bf;
     transition: 300ms;
 }
@@ -88,12 +93,14 @@ input[type="checkbox"]:checked+.toggleCircle:before {
         background-color: #66dbc6;
     }
 
-    .radio {
+    .radio,
+    select {
         background-color: #00494d;
     }
 
     .radio:hover,
-    .toggleCircle:hover {
+    .toggleCircle:hover,
+    select:hover {
         background-color: var(--dm-button-hover);
     }
 

--- a/src/components/VideoSettings/VideoSettings.service.tsx
+++ b/src/components/VideoSettings/VideoSettings.service.tsx
@@ -1,20 +1,24 @@
-import { GameSoundtrackValue, WeatherVariantValue, ISettings, LocalStorageKey, initialSettings } from "../../common";
+import { GameSoundtrackValue, GameTime, ISettings, LocalStorageKey, WeatherVariantValue, initialSettings } from '../../common';
 
 const isGameSoundtrackValue = (value: string): value is GameSoundtrackValue => Object.values(GameSoundtrackValue).includes(value as GameSoundtrackValue);
 
 const isWeatherVariantValue = (value: string): value is WeatherVariantValue => Object.values(WeatherVariantValue).includes(value as WeatherVariantValue);
 
+const isGameTime = (value: string): value is GameTime => Object.values(GameTime).includes(value as GameTime);
+
 const getBooleanSearchParamValue = (param: string | null, defaultValue: boolean): boolean => param !== null ? param === 'true' : defaultValue;
 
 export const getSettings = (searchParams: URLSearchParams): ISettings => {
     const localSettings: string | null = localStorage.getItem(LocalStorageKey.Object);
-    const { gameSoundtrack, weatherVariant, rainSoundEffectOn, thunderSoundEffectOn }: ISettings = localSettings ? JSON.parse(localSettings) : initialSettings;
+    const { gameSoundtrack, weatherVariant, rainSoundEffectOn, thunderSoundEffectOn, gameTime }: ISettings = localSettings && localSettings !== '{}' ? JSON.parse(localSettings) : initialSettings;
 
     const gameParam: string = searchParams.get("game") ?? '';
     const weatherParam: string = searchParams.get("weather") ?? '';
+    const gameTimeParam: string = searchParams.get("time") ?? '';
 
     const game: GameSoundtrackValue = isGameSoundtrackValue(gameParam) ? gameParam as GameSoundtrackValue : gameSoundtrack;
     const weather: WeatherVariantValue = isWeatherVariantValue(weatherParam) ? weatherParam as WeatherVariantValue : weatherVariant;
+    const time: GameTime = isGameTime(gameTimeParam) ? gameTimeParam as GameTime : gameTime;
     const rain: boolean = getBooleanSearchParamValue(searchParams.get("rain"), rainSoundEffectOn);
     const thunder: boolean = getBooleanSearchParamValue(searchParams.get("thunder"), thunderSoundEffectOn);
 
@@ -22,6 +26,7 @@ export const getSettings = (searchParams: URLSearchParams): ISettings => {
         gameSoundtrack: game,
         weatherVariant: weather,
         rainSoundEffectOn: rain,
-        thunderSoundEffectOn: thunder
+        thunderSoundEffectOn: thunder,
+        gameTime: time
     };
 };

--- a/src/components/VideoSettings/VideoSettings.tsx
+++ b/src/components/VideoSettings/VideoSettings.tsx
@@ -17,12 +17,13 @@ export const VideoSettings = () => {
         localStorage.setItem(LocalStorageKey.Object, JSON.stringify(settings));
     }, [settings]);
 
-    interface IHandleOptionChangeProps {
+    localStorage.setItem(LocalStorageKey.Object, JSON.stringify(getSettings(searchParams)));
+    interface IHandleRadioOptionChangeProps {
         changeEvent: ChangeEvent<HTMLInputElement>;
         stateVariable: LocalStorageKey;
     };
 
-    const handleOptionChange = ({ changeEvent, stateVariable }: IHandleOptionChangeProps): void => {
+    const handleRadioOptionChange = ({ changeEvent, stateVariable }: IHandleRadioOptionChangeProps): void => {
         const isCheckboxChanged: boolean = stateVariable == LocalStorageKey.RainSoundEffectOn || stateVariable == LocalStorageKey.ThunderSoundEffectOn;
         const value: string | boolean = isCheckboxChanged ? changeEvent.target.checked : changeEvent.target.value;
 
@@ -32,6 +33,27 @@ export const VideoSettings = () => {
         navigate({
             search: createSearchParams({
                 game: newSettings.gameSoundtrack,
+                time: `${newSettings.gameTime}`
+                // weather: newSettings.weatherVariant,
+                // rain: `${newSettings.rainSoundEffectOn}`,
+                // thunder: `${newSettings.thunderSoundEffectOn}`
+            }).toString()
+        });
+    };
+
+    interface IHandleDropdownOptionChangeProps {
+        changeEvent: ChangeEvent<HTMLSelectElement>;
+        stateVariable: LocalStorageKey;
+    };
+
+    const handleDropdownOptionChange = ({ changeEvent, stateVariable }: IHandleDropdownOptionChangeProps): void => {
+        const newSettings: ISettings = { ...settings, [stateVariable]: changeEvent.target.value };
+        setSettings(newSettings);
+
+        navigate({
+            search: createSearchParams({
+                game: newSettings.gameSoundtrack,
+                time: `${newSettings.gameTime}`
                 // weather: newSettings.weatherVariant,
                 // rain: `${newSettings.rainSoundEffectOn}`,
                 // thunder: `${newSettings.thunderSoundEffectOn}`
@@ -46,8 +68,38 @@ export const VideoSettings = () => {
                     name={LocalStorageKey.GameSoundtrack}
                     values={GameSoundtrackList}
                     selectedOption={settings.gameSoundtrack}
-                    onChange={(changeEvent) => handleOptionChange({ changeEvent, stateVariable: LocalStorageKey.GameSoundtrack })}
+                    onChange={(changeEvent) => handleRadioOptionChange({ changeEvent, stateVariable: LocalStorageKey.GameSoundtrack })}
                 />
+            </VideoSettingsGroup>
+
+            <VideoSettingsGroup title='Change hour'>
+                <select name="gameTime" id="gameTime" defaultValue={settings.gameTime} onChange={(changeEvent) => handleDropdownOptionChange({ changeEvent, stateVariable: LocalStorageKey.GameTime })}>
+                    <option value="current">Use Current</option>
+                    <option value="1AM">1am</option>
+                    <option value="2AM">2am</option>
+                    <option value="3AM">3am</option>
+                    <option value="4AM">4am</option>
+                    <option value="5AM">5am</option>
+                    <option value="6AM">6am</option>
+                    <option value="7AM">7am</option>
+                    <option value="8AM">8am</option>
+                    <option value="9AM">9am</option>
+                    <option value="10AM">10am</option>
+                    <option value="11AM">11am</option>
+                    <option value="12PM">12pm</option>
+                    <option value="1PM">1pm</option>
+                    <option value="2PM">2pm</option>
+                    <option value="3PM">3pm</option>
+                    <option value="4PM">4pm</option>
+                    <option value="5PM">5pm</option>
+                    <option value="6PM">6pm</option>
+                    <option value="7PM">7pm</option>
+                    <option value="8PM">8pm</option>
+                    <option value="9PM">9pm</option>
+                    <option value="10PM">10pm</option>
+                    <option value="11PM">11pm</option>
+                    <option value="12AM">12am</option>
+                </select>
             </VideoSettingsGroup>
 
             {/* <VideoSettingsGroup title='Change weather variant'>

--- a/src/components/VideoSettingsGroup/VideoSettingsGroup.tsx
+++ b/src/components/VideoSettingsGroup/VideoSettingsGroup.tsx
@@ -5,7 +5,7 @@ interface ISettingsGroupProps extends PropsWithChildren<{}> {
 };
 
 export const VideoSettingsGroup = ({ title, children }: ISettingsGroupProps) => (
-    <div>
+    <div className="mb-[14px]">
         <p>{title}</p>
         <div className="flex gap-[10px] text-[10px] lg:text-[14px] mt-[14px] justify-center">
             {children}

--- a/src/pages/Main/Main.tsx
+++ b/src/pages/Main/Main.tsx
@@ -7,7 +7,7 @@ export const Main = () => {
                 <div className='mt-[24px] mx-[12px]'>
                     <MainText />
                 </div>
-                <div className="flex flex-col lg:flex-row place-content-evenly items-center lg:mx-[24px]">
+                <div className="flex flex-col lg:flex-row place-content-evenly items-center mb-[24px] lg:mx-[24px]">
                     <div className="w-11/12 md:w-3/4 lg:w-1/2 h-full my-[24px]">
                         <Video />
                         {/* <VideoControls /> */}


### PR DESCRIPTION
### What does this PR do?
- adds the "Change hour" dropdown so that user can select to listen to current hour's soundtrack or a custom hour soundtrack
- dropdown also matches with what's in the local storage/URL
- slight refactoring of code

note: I discovered a bug where changing the URL will not change the app unless the screen is refreshed. Seems like it only started appearing after I switched to using HashRouter as it doesnt appear when using BrowserRouter.

### Screenshots
by default, it is on current
<img width="1440" alt="image" src="https://github.com/user-attachments/assets/1215b773-b417-477b-947b-93ae21d7456d" />
view of options in the dropdown
<img width="222" alt="image" src="https://github.com/user-attachments/assets/78d4b5ee-7aa6-43e1-9856-1695abfd6f3f" />
after changing the hour, the video and text are also changed
<img width="1440" alt="image" src="https://github.com/user-attachments/assets/c4f029dd-8b1e-41ad-886c-af94f98b8505" />


