### PR TITLE
Add weather variant selected in main text

### DIFF
--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -18,12 +18,6 @@ export const WeatherVariantList = [
     WeatherVariantValue.Random
 ];
 
-export const WeatherVariantOptionsList = [
-    WeatherVariantValue.Normal,
-    WeatherVariantValue.Rainy,
-    WeatherVariantValue.Snowy
-];
-
 export const soundtrackValueMap: Record<GameSoundtrackValue, GameSoundtrackLabel> = {
     [GameSoundtrackValue.Original]: GameSoundtrackLabel.Original,
     [GameSoundtrackValue.WWCF]: GameSoundtrackLabel.WWCF,
@@ -37,7 +31,10 @@ export const weatherValueMap: Record<WeatherVariantValue, WeatherVariantLabel> =
     [WeatherVariantValue.Normal]: WeatherVariantLabel.Normal,
     [WeatherVariantValue.Rainy]: WeatherVariantLabel.Rainy,
     [WeatherVariantValue.Snowy]: WeatherVariantLabel.Snowy,
-    [WeatherVariantValue.Random]: WeatherVariantLabel.Random
+    [WeatherVariantValue.Random]: WeatherVariantLabel.Random,
+    [WeatherVariantValue.RandomNormal]: WeatherVariantLabel.Normal,
+    [WeatherVariantValue.RandomRainy]: WeatherVariantLabel.Rainy,
+    [WeatherVariantValue.RandomSnowy]: WeatherVariantLabel.Snowy,
 };
 
 export const soundEffectValueMap: Record<SoundEffectValue, SoundEffectLabel> = {

--- a/src/common/enums.ts
+++ b/src/common/enums.ts
@@ -55,7 +55,10 @@ export enum WeatherVariantValue {
     Normal = 'normal',
     Rainy = 'rainy',
     Snowy = 'snowy',
-    Random = 'weatherVariantRandom'
+    Random = 'weatherVariantRandom',
+    RandomNormal = 'weatherVariantRandomNormal',
+    RandomRainy = 'weatherVariantRandomRainy',
+    RandomSnowy = 'weatherVariantRandomSnowy'
 };
 
 export enum WeatherVariantOptions {

--- a/src/common/service.tsx
+++ b/src/common/service.tsx
@@ -28,3 +28,7 @@ export const getSoundtrackLabelFromValue = (value: GameSoundtrackValue): GameSou
 export const getWeatherLabelFromValue = (value: WeatherVariantValue): WeatherVariantLabel => (weatherValueMap[value]);
 
 export const getSoundEffectLabelFromValue = (value: SoundEffectValue): SoundEffectLabel => (soundEffectValueMap[value]);
+
+export const isRandomWeather = (weather: WeatherVariantValue): boolean => {
+    return weather === WeatherVariantValue.RandomNormal || weather === WeatherVariantValue.RandomRainy || weather === WeatherVariantValue.RandomSnowy;
+}

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -1,4 +1,4 @@
 import { GameSoundtrackValue, WeatherVariantValue } from './enums';
 
 export type GameSoundtrackOption = GameSoundtrackValue.Original | GameSoundtrackValue.WWCF | GameSoundtrackValue.NL | GameSoundtrackValue.NH;
-export type WeatherVariantOption = WeatherVariantValue.Normal | WeatherVariantValue.Rainy | WeatherVariantValue.Snowy;
+export type WeatherVariantOption = any | WeatherVariantValue.Normal | WeatherVariantValue.Rainy | WeatherVariantValue.Snowy;

--- a/src/components/MainText/MainText.tsx
+++ b/src/components/MainText/MainText.tsx
@@ -1,6 +1,6 @@
 import { PropsWithChildren } from 'react';
-import { FormattedHour, GameSoundtrackLabel, GameSoundtrackValue } from '../../common';
-import { getHour, getSettingsFromLocalStorage, getSoundtrackLabelFromValue } from '../../common/service';
+import { FormattedHour, GameSoundtrackLabel, ISettings, WeatherVariantLabel } from '../../common';
+import { getHour, getSettingsFromLocalStorage, getSoundtrackLabelFromValue, getWeatherLabelFromValue } from '../../common/service';
 import { useTime } from '../../hooks';
 
 export const MainText = () => {
@@ -8,8 +8,16 @@ export const MainText = () => {
     const timeString: string = time.toLocaleTimeString(['en-AU'], { timeStyle: 'short' }).split(' ').join('');
     const hour: FormattedHour = getHour(time);
 
-    const soundtrackValue: GameSoundtrackValue = getSettingsFromLocalStorage().gameSoundtrack;
-    const soundtrack: GameSoundtrackLabel = getSoundtrackLabelFromValue(soundtrackValue);
+    const { gameSoundtrack, weatherVariant }: ISettings = getSettingsFromLocalStorage();
+    const soundtrack: GameSoundtrackLabel = getSoundtrackLabelFromValue(gameSoundtrack);
+    const weather: WeatherVariantLabel = getWeatherLabelFromValue(weatherVariant)
+
+    const getWeatherString = (weatherLabel: WeatherVariantLabel): string => {
+        if (weatherLabel === WeatherVariantLabel.Normal || weatherLabel === WeatherVariantLabel.Real) {
+            return '';
+        };
+        return `(${weatherLabel})`;
+    };
 
 
     const HighlightText = ({ children }: PropsWithChildren) => {
@@ -27,7 +35,7 @@ export const MainText = () => {
     return (
         <div className="font-extrabold leading-loose text-[20px] lg:text-[32px]">
             It's currently <HighlightText>{timeString}</HighlightText>!<br />
-            Now playing: <HighlightText>{hour} AC: {soundtrack} Soundtrack</HighlightText>
+            Now playing: <HighlightText>{hour} AC: {soundtrack} Soundtrack {getWeatherString(weather)}</HighlightText>
         </div>
     )
 }

--- a/src/components/Video/Video.tsx
+++ b/src/components/Video/Video.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
-import { FormattedHour, GameSoundtrackList, GameSoundtrackValue, ISettings, NHVideoId, NLVideoId, OriginalVideoId, WeatherVariantOptionsList, WeatherVariantValue, WWCFVideoId } from '../../common';
-import { getHour, getSettingsFromLocalStorage } from '../../common/service';
+import { FormattedHour, GameSoundtrackList, GameSoundtrackValue, ISettings, NHVideoId, NLVideoId, OriginalVideoId, WeatherVariantValue, WWCFVideoId } from '../../common';
+import { getHour, getSettingsFromLocalStorage, isRandomWeather } from '../../common/service';
 import { GameSoundtrackOption, WeatherVariantOption } from '../../common/types';
 import { useTime } from '../../hooks';
 
@@ -16,11 +16,6 @@ export const Video = () => {
         return GameSoundtrackList[randomNumber] as GameSoundtrackOption;
     };
 
-    const getRandomWeather = (): WeatherVariantOption => {
-        const randomNumber: number = Math.floor(Math.random() * WeatherVariantOptionsList.length);
-        return WeatherVariantOptionsList[randomNumber] as WeatherVariantOption;
-    };
-
     const getVideoId = (soundtrack: GameSoundtrackValue, weather: WeatherVariantOption, hour: FormattedHour): string => {
         const videoIdMappings: Record<string, Record<FormattedHour, Record<WeatherVariantOption, string>>> = {
             [GameSoundtrackValue.Original]: OriginalVideoId,
@@ -31,9 +26,22 @@ export const Video = () => {
         return videoIdMappings[soundtrack][hour][weather]
     };
 
+    const mapRandomWeather = (weather: WeatherVariantValue): WeatherVariantOption => {
+        switch (weather) {
+            case WeatherVariantValue.RandomNormal:
+                return WeatherVariantValue.Normal;
+            case WeatherVariantValue.RandomRainy:
+                return WeatherVariantValue.Rainy;
+            case WeatherVariantValue.RandomSnowy:
+                return WeatherVariantValue.Snowy;
+            default:
+                return WeatherVariantValue.Normal;
+        };
+    };
+
     useEffect(() => {
         const selectedSoundtrack: GameSoundtrackOption = soundtrack === GameSoundtrackValue.Random ? getRandomSoundtrack() : soundtrack;
-        const selectedWeather: WeatherVariantOption = weather === WeatherVariantValue.Random ? getRandomWeather() : weather === WeatherVariantValue.Real ? WeatherVariantValue.Normal : weather
+        const selectedWeather: WeatherVariantOption = isRandomWeather(weather) ? mapRandomWeather(weather) : weather === WeatherVariantValue.Real ? WeatherVariantValue.Normal : weather;
         setVideoId(getVideoId(selectedSoundtrack, selectedWeather, hour));
     }, [soundtrack, weather, hour]);
 

--- a/src/components/VideoSettings/VideoSettings.service.tsx
+++ b/src/components/VideoSettings/VideoSettings.service.tsx
@@ -30,3 +30,9 @@ export const getSettings = (searchParams: URLSearchParams): ISettings => {
         gameTime: time
     };
 };
+
+export const getRandomWeatherVariantValue = (): WeatherVariantValue => {
+    const randomWeatherList: WeatherVariantValue[] = [WeatherVariantValue.RandomNormal, WeatherVariantValue.RandomRainy, WeatherVariantValue.RandomSnowy];
+    const randomNumber: number = Math.floor(Math.random() * randomWeatherList.length);
+    return randomWeatherList[randomNumber];
+}


### PR DESCRIPTION
### What does this PR do?
- Shows the weather variant currently playing in the main text if the variant is not normal - will show rainy or snowy
  - currently have set real to be the same as normal for now
 
- Changes in the way random weather is selected:
  - Sets the random weather in local storage on load or when Random button is selected - this lets the video, setting buttons and main text to use the same weather variant
  - If weather is random in URL, then it'll choose the random weather on load

### Screenshots
Rainy/Snowy selected = shows rainy/snowy
<img width="1440" alt="image" src="https://github.com/user-attachments/assets/4d32e21e-c253-4581-ab6c-7afee5b8c90e" />

<img width="1440" alt="image" src="https://github.com/user-attachments/assets/ecd02193-02de-4c8e-bdad-c5cd60693b2c" />
Real or Normal selected = does not display weather variant
<img width="1440" alt="image" src="https://github.com/user-attachments/assets/be4a4f07-8f10-45be-8c3a-7b89f310a4a3" />

Random selected = selects random and shows variant (rainy/snowy) or none if variant is real/normal
<img width="1440" alt="image" src="https://github.com/user-attachments/assets/5660f7a0-84af-469c-9624-5a7cc4ebfe65" />


